### PR TITLE
Build fixes for rocm-from-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Default flags: --master --release
 |roct| master | dev |
 |rocr| master | dev |
 |hcc-hsail| master | develop |
-|hcc-lc| testing | master |
+|hcc-lc| master | master |
 
 ### Docker compose
 `./rocm-setup` prepares an environment that can be controlled with [Docker Compose](https://docs.docker.com/compose/).  An output of the script is a **docker-compose.yml** file in the root of the repository, which coordinates the relationships between the various ROCm software layers.  Additionally, the  docker-compose.yml file can be extended to easily launch interactive application or development containers built on top of the ROCm software stack.  

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -49,7 +49,7 @@ services:
       - ${hcc_hsail_volume}
 
   # The following defines application containers, which depend on the data-only
-  # containers defiend above to provide their software layers
+  # containers defined above to provide their software layers
   # These should be run with `docker-compose run --rm <application-service>`
   rocm:
     build:

--- a/hcc-lc/hcc-lc-dockerfile.template
+++ b/hcc-lc/hcc-lc-dockerfile.template
@@ -16,7 +16,6 @@ CMD ["-l"]
 # Install dependencies required to build hcc
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   build-essential \
-  cmake \
   git \
   curl \
   wget \
@@ -30,6 +29,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # App specific environment variables; modify path to add hcc and repo commands
 ENV HCC_BUILD_PATH=/usr/local/src/hcc-lc
 ENV PATH=${PATH}:${hcc_lc_volume}/bin:~/bin
+
+# Build cmake from scratch to support newer versions of LLVM
+RUN wget http://www.cmake.org/files/v3.6/cmake-3.6.0.tar.gz && \
+    tar xf cmake-3.6.0.tar.gz && \
+    cd cmake-3.6.0 && \
+    ./configure && \
+    make && \
+    make install &&\
+    cd .. &&\
+    rm -rf cmake-3.6.0.tar.gz cmake-3.6.0
 
 # Compiling hcc-lc requires a custom build tool
 RUN mkdir -p ~/bin && \

--- a/rocm-setup.sh
+++ b/rocm-setup.sh
@@ -77,7 +77,7 @@ export repo_branch_rocr="master"
 if [ -n "${build_master}" ]; then
   repo_branch="master"
   repo_branch_hcc_hsail="master"
-  repo_branch_hcc_lc="testing"
+  repo_branch_hcc_lc="master"
 else
   repo_branch="dev"
   repo_branch_hcc_hsail="master"  # temp


### PR DESCRIPTION
The hcc-lc repository no longer works with the testing branch; HCC-Native-GCN-ISA's [default.xml](https://github.com/RadeonOpenCompute/HCC-Native-GCN-ISA/blob/testing/default.xml) does not have the entry for LLVM-AMDGPU-Assembler-Extra specified which causes `docker-compose run --rm rocm-from-src` to fail during build.

The default cmake version retrieved from APT is too old to work with LLVM with the master branch so I also added code build a newer version from scratch.