### PR TITLE
Update cmake version for LLVM

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -49,7 +49,7 @@ services:
       - ${hcc_hsail_volume}
 
   # The following defines application containers, which depend on the data-only
-  # containers defiend above to provide their software layers
+  # containers defined above to provide their software layers
   # These should be run with `docker-compose run --rm <application-service>`
   rocm:
     build:

--- a/hcc-lc/hcc-lc-dockerfile.template
+++ b/hcc-lc/hcc-lc-dockerfile.template
@@ -16,7 +16,6 @@ CMD ["-l"]
 # Install dependencies required to build hcc
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   build-essential \
-  cmake \
   git \
   curl \
   wget \
@@ -30,6 +29,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # App specific environment variables; modify path to add hcc and repo commands
 ENV HCC_BUILD_PATH=/usr/local/src/hcc-lc
 ENV PATH=${PATH}:${hcc_lc_volume}/bin:~/bin
+
+# Build cmake from scratch to support newer versions of LLVM
+RUN wget http://www.cmake.org/files/v3.6/cmake-3.6.1.tar.gz && \
+    tar xf cmake-3.6.1.tar.gz && \
+    cd cmake-3.6.1 && \
+    ./configure && \
+    make && \
+    make install &&\
+    cd .. &&\
+    rm -rf cmake-3.6.1.tar.gz cmake-3.6.1
 
 # Compiling hcc-lc requires a custom build tool
 RUN mkdir -p ~/bin && \


### PR DESCRIPTION
LLVM requires a newer version of cmake that is not available in the standard APT repositories for Ubuntu 14.04. This request removes the APT installation for cmake and builds cmake from source with a more recent version. 

Also, the request includes a minor spelling fix in one of the template files.