### PR TITLE
Updating hcc-lc docker to use clang_tot_upgrade branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,12 @@ Default flags: --master --release
 
 || --master | --develop |
 |------|-----|-----|
-|roct| master | dev |
-|rocr| master | dev |
-|hcc-hsail| master | develop |
-|hcc-lc| testing | master |
+|roct| master | master |
+|rocr| master | master |
+|hcc-hsail| master | master |
+|hcc-lc| clang_tot_upgrade | clang_tot_upgrade |
+
+##### When building ROCm components from source, we are locking down branches to known good configurations.
 
 ### Docker compose
 `./rocm-setup` prepares an environment that can be controlled with [Docker Compose](https://docs.docker.com/compose/).  An output of the script is a **docker-compose.yml** file in the root of the repository, which coordinates the relationships between the various ROCm software layers.  Additionally, the  docker-compose.yml file can be extended to easily launch interactive application or development containers built on top of the ROCm software stack.  

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -57,7 +57,7 @@ services:
       dockerfile: Dockerfile
     devices:
       - "/dev/kfd"
-    image: rocm/terminal
+    image: rocm/rocm-terminal
     volumes:
       - ~:/usr/local/src/host-home
 
@@ -67,7 +67,7 @@ services:
       dockerfile: Dockerfile
     devices:
       - "/dev/kfd"
-    image: rocm/terminal
+    image: rocm/rocm-terminal
     volumes:
       - ~:/usr/local/src/host-home
     volumes_from:

--- a/hcc-lc/hcc-lc-dockerfile.template
+++ b/hcc-lc/hcc-lc-dockerfile.template
@@ -14,23 +14,34 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl \
   wget \
   python \
+  libncurses5-dev \
   libelf-dev \
   libc++abi-dev \
   libc++-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
+# These are all extra packages needed to build cmake with --system-libs
+#  zlib1g-dev \
+#  libcurl4-openssl-dev \
+#  lzma-dev \
+#  libbz2-dev \
+#  libarchive-dev \
+#  lib64expat1-dev \
+#  libjsoncpp-dev \
+
 # Download and install an up to date version of cmake, because compiling
 # LLVM has implemented a requirement of cmake v4.3.4 or greater
-# This installs the new cmake side-by-side with the old cmake using update-alternatives
 ENV CMAKE_VER_MAJOR 3.6
 ENV CMAKE_VER_MINOR ${CMAKE_VER_MAJOR}.2
 ENV CMAKE_PREFIX /opt/cmake
 
+# This installs the new cmake side-by-side with the old cmake using update-alternatives
 RUN cd ~ && mkdir -p src && cd src && \
     curl -L https://cmake.org/files/v${CMAKE_VER_MAJOR}/cmake-${CMAKE_VER_MINOR}.tar.gz -o cmake-${CMAKE_VER_MINOR}.tar.gz && \
     tar -xf cmake-${CMAKE_VER_MINOR}.tar.gz && \
     cd ~/src/cmake-${CMAKE_VER_MINOR} && \
+#    ./bootstrap --prefix=${CMAKE_PREFIX} --system-libs && \
     ./bootstrap --prefix=${CMAKE_PREFIX} && \
     make -j $(nproc) && \
     make install && \
@@ -45,6 +56,7 @@ RUN mkdir -p ~/bin && \
     curl http://commondatastorage.googleapis.com/git-repo-downloads/repo > ~/bin/repo && \
     chmod a+x ~/bin/repo
 
+# This is a long series of build steps, all listed under one RUN statement to keep image size down
 # Build hcc-lc, install to /usr/local
 RUN mkdir -p ${HCC_BUILD_PATH} && \
   cd ${HCC_BUILD_PATH} && \
@@ -65,26 +77,75 @@ RUN mkdir -p ${HCC_BUILD_PATH} && \
   cd ../../ocml/ && \
   mkdir -p build && \
   cd build && \
-  CC=${HCC_BUILD_PATH}/bin/clang cmake \
+  CC=${HCC_BUILD_PATH}/llvm/build/bin/clang cmake \
     -DCMAKE_INSTALL_PREFIX=${hcc_lc_volume} \
     -DCMAKE_BUILD_TYPE=${build_config} \
     -DAMDHSACOD=/opt/rocm/bin/amdhsacod \
-    -DLLVM_DIR="${HCC_BUILD_PATH}/llvm/build" .. && \
+    -DLLVM_DIR="${HCC_BUILD_PATH}/llvm/build" \
+    .. && \
   make -j $(nproc) install && \
 
   # build HCC with ROCm-Device-Libs
   cd ../../hcc && \
   mkdir -p build && \
   cd build && \
-  ln -sr ${rocr_volume}/include ${rocr_volume}/include/hsa && \
   cmake \
     -DCMAKE_INSTALL_PREFIX=${hcc_lc_volume} \
     -DCMAKE_BUILD_TYPE=${build_config} \
     -DHSA_AMDGPU_GPU_TARGET=AMD:AMDGPU:8:0:3 \
-    -DROCM_DEVICE_LIB_DIR=${HCC_BUILD_PATH}/ocml/build/dist/lib .. && \
+    -DROCM_DEVICE_LIB_DIR=${hcc_lc_volume}/lib \
+    .. && \
   make -j $(nproc) world && \
   make install && \
   git log -n 3 > ${hcc_lc_volume}/git-stamp.log && \
   ${hcc_lc_cleanup} \
   echo "${hcc_lc_volume}/lib" >> /etc/ld.so.conf.d/hcc-lc.conf && \
   ldconfig
+
+
+## The following build steps are seperated into multiple RUN statements to debug each individual component build
+## It results in about double the image size
+## Build hcc-lc, install to /usr/local
+#RUN mkdir -p ${HCC_BUILD_PATH} && \
+#  cd ${HCC_BUILD_PATH} && \
+#  ~/bin/repo init --depth=1 -u https://github.com/RadeonOpenCompute/HCC-Native-GCN-ISA.git -b ${repo_branch_hcc_lc} && \
+#  ~/bin/repo sync
+
+#  # build amd-common LLVM/LLD/Clang
+#RUN cd ${HCC_BUILD_PATH}/llvm && \
+#  mkdir -p build && \
+#  cd build && \
+#  cmake \
+#    -DCMAKE_INSTALL_PREFIX=${hcc_lc_volume} \
+#    -DCMAKE_BUILD_TYPE=${build_config} \
+#    -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" .. && \
+#  make -j $(nproc) install
+
+#  # build ROCm-Device-Libs with amd-common Clang
+#RUN cd ${HCC_BUILD_PATH}/ocml/ && \
+#  mkdir -p build && \
+#  cd build && \
+#  CC=${HCC_BUILD_PATH}/llvm/build/bin/clang cmake \
+#    -DCMAKE_INSTALL_PREFIX=${hcc_lc_volume} \
+#    -DCMAKE_BUILD_TYPE=${build_config} \
+#    -DAMDHSACOD=/opt/rocm/bin/amdhsacod \
+#    -DLLVM_DIR="${HCC_BUILD_PATH}/llvm/build" \
+#    .. && \
+#  make -j $(nproc) install
+
+#  # build HCC with ROCm-Device-Libs
+#RUN cd ${HCC_BUILD_PATH}/hcc && \
+#  mkdir -p build && \
+#  cd build && \
+#  cmake \
+#    -DCMAKE_INSTALL_PREFIX=${hcc_lc_volume} \
+#    -DCMAKE_BUILD_TYPE=${build_config} \
+#    -DHSA_AMDGPU_GPU_TARGET=AMD:AMDGPU:8:0:3 \
+#    -DROCM_DEVICE_LIB_DIR=${hcc_lc_volume}/lib \
+#    .. && \
+#  make -j $(nproc) world && \
+#  make install && \
+#  git log -n 3 > ${hcc_lc_volume}/git-stamp.log && \
+#  ${hcc_lc_cleanup} \
+#  echo "${hcc_lc_volume}/lib" >> /etc/ld.so.conf.d/hcc-lc.conf && \
+#  ldconfig

--- a/hcc-lc/hcc-lc-dockerfile.template
+++ b/hcc-lc/hcc-lc-dockerfile.template
@@ -4,14 +4,8 @@
 # most changing at bottom
 
 # This builds the hcc compiler, and depends on an already existing rocr-runtime to be found
-
-# ubuntu:14.04.3, the native kernel is '3.19'
 FROM ${rocr_name}
 MAINTAINER Kent Knox <kent.knox@amd>
-
-# Default to a login shell
-ENTRYPOINT ["/bin/bash"]
-CMD ["-l"]
 
 # Install dependencies required to build hcc
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -26,19 +20,25 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
+# Download and install an up to date version of cmake, because compiling
+# LLVM has implemented a requirement of cmake v4.3.4 or greater
+# This installs the new cmake side-by-side with the old cmake using update-alternatives
+ENV CMAKE_VER_MAJOR 3.6
+ENV CMAKE_VER_MINOR ${CMAKE_VER_MAJOR}.2
+ENV CMAKE_PREFIX /opt/cmake
+
+RUN cd ~ && mkdir -p src && cd src && \
+    curl -L https://cmake.org/files/v${CMAKE_VER_MAJOR}/cmake-${CMAKE_VER_MINOR}.tar.gz -o cmake-${CMAKE_VER_MINOR}.tar.gz && \
+    tar -xf cmake-${CMAKE_VER_MINOR}.tar.gz && \
+    cd ~/src/cmake-${CMAKE_VER_MINOR} && \
+    ./bootstrap --prefix=${CMAKE_PREFIX} && \
+    make -j $(nproc) && \
+    make install && \
+    update-alternatives --install /usr/local/bin/cmake cmake ${CMAKE_PREFIX}/bin/cmake 80 --slave /usr/local/bin/ccmake ccmake ${CMAKE_PREFIX}/bin/ccmake --slave /usr/local/bin/cpack cpack ${CMAKE_PREFIX}/bin/cpack --slave /usr/local/bin/ctest ctest ${CMAKE_PREFIX}/bin/ctest --slave /usr/local/share/cmake-${CMAKE_VER_MAJOR} share-cmake-${CMAKE_VER_MAJOR} ${CMAKE_PREFIX}/share/cmake-${CMAKE_VER_MAJOR} # --slave /usr/local/bin/cmake-gui cmake-gui ${CMAKE_PREFIX}/bin/cmake-gui
+
 # App specific environment variables; modify path to add hcc and repo commands
 ENV HCC_BUILD_PATH=/usr/local/src/hcc-lc
-ENV PATH=${PATH}:${hcc_lc_volume}/bin:~/bin
-
-# Build cmake from scratch to support newer versions of LLVM
-RUN wget http://www.cmake.org/files/v3.6/cmake-3.6.1.tar.gz && \
-    tar xf cmake-3.6.1.tar.gz && \
-    cd cmake-3.6.1 && \
-    ./configure && \
-    make && \
-    make install &&\
-    cd .. &&\
-    rm -rf cmake-3.6.1.tar.gz cmake-3.6.1
+ENV PATH=${PATH}:${hcc_lc_volume}bin:~/bin
 
 # Compiling hcc-lc requires a custom build tool
 RUN mkdir -p ~/bin && \
@@ -50,6 +50,8 @@ RUN mkdir -p ${HCC_BUILD_PATH} && \
   cd ${HCC_BUILD_PATH} && \
   ~/bin/repo init --depth=1 -u https://github.com/RadeonOpenCompute/HCC-Native-GCN-ISA.git -b ${repo_branch_hcc_lc} && \
   ~/bin/repo sync && \
+
+  # build amd-common LLVM/LLD/Clang
   cd llvm && \
   mkdir -p build && \
   cd build && \
@@ -59,17 +61,18 @@ RUN mkdir -p ${HCC_BUILD_PATH} && \
     -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" .. && \
   make -j $(nproc) install && \
 
-  cd ../../llvm-amdgpu-assembler-extra/ && \
+  # build ROCm-Device-Libs with amd-common Clang
+  cd ../../ocml/ && \
   mkdir -p build && \
   cd build && \
-  cmake \
+  CC=${HCC_BUILD_PATH}/bin/clang cmake \
     -DCMAKE_INSTALL_PREFIX=${hcc_lc_volume} \
     -DCMAKE_BUILD_TYPE=${build_config} \
-    -DBUILD_EXAMPLES=OFF \
-    -DHSA_ROOT=${rocr_volume} \
+    -DAMDHSACOD=/opt/rocm/bin/amdhsacod \
     -DLLVM_DIR="${HCC_BUILD_PATH}/llvm/build" .. && \
   make -j $(nproc) install && \
 
+  # build HCC with ROCm-Device-Libs
   cd ../../hcc && \
   mkdir -p build && \
   cd build && \
@@ -77,11 +80,8 @@ RUN mkdir -p ${HCC_BUILD_PATH} && \
   cmake \
     -DCMAKE_INSTALL_PREFIX=${hcc_lc_volume} \
     -DCMAKE_BUILD_TYPE=${build_config} \
-    -DROCM_ROOT=${rocr_volume} \
-    -DHSA_LLVM_BIN_DIR=${hcc_lc_volume}/bin \
-    -DHSA_AMDGPU_GPU_TARGET=fiji \
-    -DAMDPHDRS_DIR=${hcc_lc_volume}/bin \
-    -DHSA_USE_AMDGPU_BACKEND=ON .. && \
+    -DHSA_AMDGPU_GPU_TARGET=AMD:AMDGPU:8:0:3 \
+    -DROCM_DEVICE_LIB_DIR=${HCC_BUILD_PATH}/ocml/build/dist/lib .. && \
   make -j $(nproc) world && \
   make install && \
   git log -n 3 > ${hcc_lc_volume}/git-stamp.log && \

--- a/rocm-setup.sh
+++ b/rocm-setup.sh
@@ -81,7 +81,7 @@ if [ -n "${build_master}" ]; then
 else
   repo_branch="dev"
   repo_branch_hcc_hsail="master"  # temp
-  repo_branch_hcc_lc="master"
+  repo_branch_hcc_lc="clang_tot_upgrade"
 fi
 
 export build_config=
@@ -134,7 +134,6 @@ export hcc_lc_volume='/opt/rocm/hcc-lc/'
 # export lib64_install_dir='/lib/x86_64-linux-gnu'
 export lib64_install_dir='/lib'
 
-# Uncomment below to print dockerfiles with template substitutions; debugging
 cat rock/rock-deb-dockerfile.template | envsubst '${repo_branch}:${rock_volume}' > rock/Dockerfile
 cat roct/roct-thunk-dockerfile.template | envsubst '${rock_name}:${repo_branch}:${build_config_roct}:${roct_cleanup}:${roct_volume}:${lib64_install_dir}' > roct/Dockerfile
 cat rocr/rocr-make-dockerfile.template | envsubst '${roct_name}:${repo_branch_rocr}:${build_config}:${rocr_cleanup}:${roct_volume}:${rocr_volume}:${lib64_install_dir}' > rocr/Dockerfile

--- a/rocm-setup.sh
+++ b/rocm-setup.sh
@@ -69,18 +69,16 @@ while :; do
 done
 
 # hcc-lc conforms to a non git-flow naming scheme, 'master' changes the most
-export repo_branch=
+export repo_branch="master"
 export repo_branch_hcc_lc=
 export repo_branch_hcc_hsail=
 export repo_branch_rocr="master"
 
 if [ -n "${build_master}" ]; then
-  repo_branch="master"
   repo_branch_hcc_hsail="master"
-  repo_branch_hcc_lc="testing"
+  repo_branch_hcc_lc="clang_tot_upgrade"
 else
-  repo_branch="dev"
-  repo_branch_hcc_hsail="master"  # temp
+  repo_branch_hcc_hsail="master"
   repo_branch_hcc_lc="clang_tot_upgrade"
 fi
 
@@ -125,18 +123,20 @@ else
   hcc_lc_name="${rocm_prefix}hcc-lc-${repo_branch_hcc_lc}-${build_config,}"
 fi
 
-export rock_volume='/opt/rocm/rock/'
-export roct_volume='/opt/rocm/libhsakmt/'
-export rocr_volume='/opt/rocm/hsa/'
-export hcc_hsail_volume='/opt/rocm/hcc-hsail/'
-export hcc_lc_volume='/opt/rocm/hcc-lc/'
+export rocm_volume='/opt/rocm/'
+export rock_volume="${rocm_volume}rock/"
+export roct_volume="${rocm_volume}libhsakmt/"
+export rocr_volume="${rocm_volume}hsa/"
+export hcc_hsail_volume="${rocm_volume}hcc-hsail/"
+export hcc_lc_volume="${rocm_volume}hcc-lc/"
 
+# /lib/x86_64-linux-gnu is debian/ubuntu style not currently used in rocm
 # export lib64_install_dir='/lib/x86_64-linux-gnu'
 export lib64_install_dir='/lib'
 
 cat rock/rock-deb-dockerfile.template | envsubst '${repo_branch}:${rock_volume}' > rock/Dockerfile
 cat roct/roct-thunk-dockerfile.template | envsubst '${rock_name}:${repo_branch}:${build_config_roct}:${roct_cleanup}:${roct_volume}:${lib64_install_dir}' > roct/Dockerfile
-cat rocr/rocr-make-dockerfile.template | envsubst '${roct_name}:${repo_branch_rocr}:${build_config}:${rocr_cleanup}:${roct_volume}:${rocr_volume}:${lib64_install_dir}' > rocr/Dockerfile
+cat rocr/rocr-make-dockerfile.template | envsubst '${roct_name}:${repo_branch_rocr}:${build_config}:${rocr_cleanup}:${rocm_volume}:${roct_volume}:${rocr_volume}:${lib64_install_dir}' > rocr/Dockerfile
 cat hcc-hsail/hcc-hsail-dockerfile.template | envsubst '${rocr_name}:${repo_branch_hcc_hsail}:${build_config}:${hcc_hsail_cleanup}:${roct_volume}:${rocr_volume}:${hcc_hsail_volume}:${lib64_install_dir}' > hcc-hsail/Dockerfile
 cat hcc-lc/hcc-lc-dockerfile.template | envsubst '${rocr_name}:${repo_branch_hcc_lc}:${build_config}:${hcc_lc_cleanup}:${roct_volume}:${rocr_volume}:${hcc_lc_volume}' > hcc-lc/Dockerfile
 

--- a/rocr/rocr-make-dockerfile.template
+++ b/rocr/rocr-make-dockerfile.template
@@ -7,10 +7,6 @@
 FROM ${roct_name}
 MAINTAINER Kent Knox <kent.knox@amd>
 
-# Default to a login shell
-ENTRYPOINT ["/bin/bash"]
-CMD ["-l"]
-
 # The following imports a key to the external AMD packages repository to make it trusted
 # HSAIL based tools (hcc-hsail) need the finalizer libraries, which are closed source and not provided on github
 # Hopefully, this can be removed in the future when dependencies on closed source blobs are removed
@@ -23,7 +19,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl && 
   libelf-dev \
   git \
   hsa-ext-rocr-dev \
-  cmake && \
+  cmake-curses-gui && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
@@ -38,7 +34,7 @@ RUN mkdir -p ${ROCR_BUILD_PATH} && \
   mkdir -p build && \
   cd build && \
     cmake \
-      -DHSATHK_BUILD_INC_PATH=${roct_volume}/include/libhsakmt \
+      -DHSATHK_BUILD_INC_PATH=${roct_volume}include/libhsakmt \
       -DHSATHK_BUILD_LIB_PATH=${roct_volume}${lib64_install_dir} \
       -DCMAKE_INSTALL_PREFIX=${rocr_volume} \
       -DCMAKE_BUILD_TYPE=${build_config} \
@@ -46,6 +42,8 @@ RUN mkdir -p ${ROCR_BUILD_PATH} && \
   make -j $(nproc) install && \
   cp -r ../src/inc ${rocr_volume}/include && \
   cp -r ../sample ${rocr_volume}/sample && \
+  ln -sr ${rocr_volume}/include/ ${rocm_volume}/include/hsa && \
+  ln -sr ${rocr_volume}/lib/libhsa-runtime64.so.1 ${rocm_volume}/lib/libhsa-runtime64.so && \
   git log -n 3 > ${rocr_volume}/git-stamp.log && \
   ${rocr_cleanup} \
   echo "${rocr_volume}lib" >> /etc/ld.so.conf.d/hsa-rocr-dev.conf && \

--- a/roct/roct-thunk-dockerfile.template
+++ b/roct/roct-thunk-dockerfile.template
@@ -5,33 +5,39 @@
 
 # This builds the radeon open compute kernel thunk
 
-# ubuntu:14.04.3, the native kernel is '3.19'
 FROM ubuntu:14.04
 MAINTAINER Kent Knox <kent.knox@amd>
 
-# Default to a login shell
-ENTRYPOINT ["/bin/bash"]
-CMD ["-l"]
-
 # Initialize the image we are working with
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl && \
+  curl -sL http://packages.amd.com/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+  sh -c 'echo deb [arch=amd64] http://packages.amd.com/rocm/apt/debian/ trusty main > /etc/apt/sources.list.d/rocm.list' && \
+  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  hsakmt-roct-dev \
   build-essential \
-  git && \
+  git \
+  cmake-curses-gui && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
 # App specific environment variables
 ENV HSATHK_BUILD_PATH=/usr/local/src/ROCT-Thunk-Interface
 
-RUN mkdir -p ${HSATHK_BUILD_PATH} && \
-  cd ${HSATHK_BUILD_PATH} && \
-  git clone --depth=1 --branch=${repo_branch} https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface.git ./ && \
-  make -j $(nproc) ${build_config_roct} all deb && \
-  mkdir -p ${roct_volume}${lib64_install_dir} && \
-  mkdir -p ${roct_volume}/include/libhsakmt && \
-  cp -a include/* ${roct_volume}/include/libhsakmt && \
-  cp -a build/lnx64a/lib*.so* ${roct_volume}${lib64_install_dir} && \
-  git log -n 3 > ${roct_volume}/git-stamp.log && \
-  ${roct_cleanup} \
-  echo "${roct_volume}${lib64_install_dir}" >> /etc/ld.so.conf.d/x86_64-libhsakmt.conf && \
-  ldconfig
+RUN ln -sr ${roct_volume}lib/libhsakmt.so.1 ${roct_volume}lib/libhsakmt.so
+
+# Uncomment the following code when ROCT-Thunk-Interface cmake code successfully builds
+## Build libhsakmt
+#RUN mkdir -p ${HSATHK_BUILD_PATH} && \
+#  cd ${HSATHK_BUILD_PATH} && \
+#  git clone --depth=1 --branch=${repo_branch} https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface.git ./ && \
+#  mkdir -p build && \
+#  cd build && \
+#    cmake \
+#      -DCMAKE_INSTALL_PREFIX=${roct_volume} \
+#      -DCMAKE_BUILD_TYPE=${build_config} \
+#    .. && \
+#  make -j $(nproc) install && \
+#  git log -n 3 > ${roct_volume}/git-stamp.log && \
+#  ${roct_cleanup} \
+#  echo "${roct_volume}${lib64_install_dir}" >> /etc/ld.so.conf.d/x86_64-libhsakmt.conf && \
+#  ldconfig


### PR DESCRIPTION
clang_tot_upgrade branch contains the hcc 4.0 compiler
Switched roct & rocr to always use master branch, because they are getting the new code