### PR TITLE
Adding dev/* dockerfiles meant to serve as base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ When working with the ROCm containers, the following are common and useful docke
   * Follow the documentation in the [quick start guide](quick-start.md) for a solution to change to the storage driver
 
 #### Saving work in a container
-Docker containers are typically ephemeral, and are discarded after closing the container with the '**--rm**' flag to `docker run`.  However, there are times when it is desirable to close a container that has arbitrary work in it, and serialize it back into a docker image.  This may be to to create a checkpoint in a long and complicated series of instructions, or it may be desired to share the image with others through a docker registry, such as docker hub.  
+Docker containers are typically ephemeral, and are discarded after closing the container with the '**--rm**' flag to `docker run`.  However, there are times when it is desirable to close a container that has arbitrary work in it, and serialize it back into a docker image.  This may be to to create a checkpoint in a long and complicated series of instructions, or it may be desired to share the image with others through a docker registry, such as docker hub.
 
 ```bash
 sudo docker ps -a  # Find container of interest
@@ -49,7 +49,7 @@ An [apt-get repository](https://github.com/RadeonOpenCompute/ROCm/wiki#installin
 
 ## Building images
 There are two ways to install rocm components:
-1.  install from the rocm apt/rpm repository (packages.amd.com)
+1.  install from the rocm apt/rpm repository (repo.radeon.com)
 2.  build the components from source and run install scripts
 
 The first method produces docker images with the smallest footprint and best building speed.  The footprint is smaller because no developer tools need to be installed in the image, an the images build speed is fastest because typically downloading binaries is much faster than downloading source and then invoking a build process.  Of course, building components allows much greater flexibility on install location and the ability to step through the source with debug builds.  ROCm-docker supports making images either way, and depends on the flags passed to the setup script.
@@ -57,7 +57,7 @@ The first method produces docker images with the smallest footprint and best bui
 The setup script included in this repository is provides some flexibility to how docker containers are constructed.  Unfortunately, Dockerfiles do not have a preprocessor or template language, so typically build instructions are hardcoded.  However, the setup script allows us to write a primitive 'template', and after running it instantiates baked dockerfiles with environment variables substituted in.  For instance, if you wish to build release images and debug images, first run the setup script to generate release dockerfiles and build the images.  Then, run the setup script again and specify debug dockerfiles and build new images.  The docker images should generate unique image names and not conflict with each other.
 
 ## setup.sh
-Currently, the setup.sh scripts checks to make sure that it is running on an **Ubuntu system**, as it makes a few assumptions about the availability of tools and file locations.  If running rocm on a Fedora machine, inspect the source of setup.sh and issue the appropriate commands manually.  There are a few parameters to setup.sh of a generic nature that affects all images built after running.  If no parameters are given, built images will be based off of Ubuntu 16.04 with rocm components installed from debians downloaded from packages.amd.com.  Supported parameters can be queried with `./setup --help`.
+Currently, the setup.sh scripts checks to make sure that it is running on an **Ubuntu system**, as it makes a few assumptions about the availability of tools and file locations.  If running rocm on a Fedora machine, inspect the source of setup.sh and issue the appropriate commands manually.  There are a few parameters to setup.sh of a generic nature that affects all images built after running.  If no parameters are given, built images will be based off of Ubuntu 16.04 with rocm components installed from debians downloaded from repo.radeon.com.  Supported parameters can be queried with `./setup --help`.
 
 | setup.sh parameters | parameter [default]| description |
 |-----|-----|-----|
@@ -75,10 +75,10 @@ The following parameters are specific to building containers that compile rocm c
 `./setup` generates finalized Dockerfiles from textual template files ending with the *.template* suffix.  Each sub-directory of this repository corresponds to a docker 'build context' responsible for a software layer in the ROCm stack.  After running the script, each directory contains generated dockerfiles for building images from debians and from source.
 
 ### Docker compose
-`./setup` prepares an environment to be controlled with [Docker Compose](https://docs.docker.com/compose/).  While docker-compose is not necessary for proper operation, it is highly recommended.  setup.sh does provide a flag to simplify the installation of this tool. Docker-compose coordinates the relationships between the various ROCm software layers, and it remembers flags that should be passed to docker to expose devices and import volumes.  
+`./setup` prepares an environment to be controlled with [Docker Compose](https://docs.docker.com/compose/).  While docker-compose is not necessary for proper operation, it is highly recommended.  setup.sh does provide a flag to simplify the installation of this tool. Docker-compose coordinates the relationships between the various ROCm software layers, and it remembers flags that should be passed to docker to expose devices and import volumes.
 
 #### Example of using docker-compose
-docker-compose.yml provides services that build and run containers.  YAML is structured data, so it's easy to modify and extend.  The *setup.sh* script generates a *.env* file that docker-compose reads to satisfy the definitions of the variables in the .yml file.  
+docker-compose.yml provides services that build and run containers.  YAML is structured data, so it's easy to modify and extend.  The *setup.sh* script generates a *.env* file that docker-compose reads to satisfy the definitions of the variables in the .yml file.
   * `docker-compose run --rm rocm` -- Run container using rocm packages
   * `docker-compose run --rm rocm-from-src` -- Run container with rocm built from source
 
@@ -91,7 +91,7 @@ docker-compose.yml provides services that build and run containers.  YAML is str
   | rocm | application service defined in **docker-compose.yml** |
 
 ### rocm-user has root privileges by default
-The dockerfile that serves as a 'terminal' creates a non-root user called **rocm-user**.  This container is meant to serve as a development environment (therefore `apt-get` is likely needed), the user has been added to the linux sudo group.  Since it is somewhat difficult to set and change passwords in a container (often requiring a rebuild), the password prompt has been disabled for the sudo group.  While this is convenient for development to be able `sudo apt-get install` packages, it does imply *lower security* in the container.  
+The dockerfile that serves as a 'terminal' creates a non-root user called **rocm-user**.  This container is meant to serve as a development environment (therefore `apt-get` is likely needed), the user has been added to the linux sudo group.  Since it is somewhat difficult to set and change passwords in a container (often requiring a rebuild), the password prompt has been disabled for the sudo group.  While this is convenient for development to be able `sudo apt-get install` packages, it does imply *lower security* in the container.
 
 To increase container security:
 

--- a/dev/Dockerfile-fedora-24
+++ b/dev/Dockerfile-fedora-24
@@ -1,0 +1,12 @@
+# This dockerfile is meant to serve as a rocm base image.  It registers the dnf rocm package repository, and
+# installs the rocm-dev package.
+
+FROM fedora:24
+LABEL maintainer=kent.knox@amd
+
+# Register the ROCM package repository, and install rocm-dev package
+RUN dnf -y update \
+  && printf "[remote]\nname=ROCm Repo\nbaseurl=http://repo.radeon.com/rocm/yum/rpm/\nenabled=1\ngpgcheck=0\n" | tee /etc/yum.repos.d/rocm.repo \
+  && dnf -y install \
+    rocm-dev \
+  && dnf -y clean all

--- a/dev/Dockerfile-ubuntu-16.04
+++ b/dev/Dockerfile-ubuntu-16.04
@@ -1,0 +1,14 @@
+# This dockerfile is meant to serve as a rocm base image.  It registers the debian rocm package repository, and
+# installs the rocm-dev package.
+
+FROM ubuntu:16.04
+LABEL maintainer=kent.knox@amd
+
+# Register the ROCM package repository, and install rocm-dev package
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl \
+  && curl -sL http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | apt-key add - \
+  && printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | tee /etc/apt/sources.list.d/rocm.list \
+  && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    rocm-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,5 @@
 version: '2.1'
 
-# Manually create these data volumes on the command line like so:
-# docker volume create --name cmake-x.x.x
-#
-# In order to use the home volume, there appears to be an initialization bug
-# with named volumes.  I was able to get around it by explicitely initializing
-# docker run -it --rm -v client-home:/home rocm/jenkins-client bash -l
-#
-# The etc shared volume is necessary to preserve passwd and supporting files 
-# when rebuilding the image.  I hope in the future a better way can be found to 
-# preserve user and password information than saving the entire /etc
-volumes:
-  hcc-lc:
-    external:
-      name: hcc-lc-${HCC_VERSION}
-  hip:
-    external:
-      name: hip-${HCC_VERSION}
 
 services:
 # The following are images built from debians downloaded from a package repository
@@ -74,21 +57,6 @@ services:
       dockerfile: ${hcc_lc_src_dockerfile}
     image: ${hcc_lc_image_name_src}
     container_name: hcc-lc-src
-    volumes:
-      - hcc-lc:${hcc_lc_volume}
-      - hip:/opt/rocm/hip
-
-  # hcc-hsail:
-  #   depends_on:
-  #     - rocr
-  #   build:
-  #     context: ./hcc-hsail
-  #     dockerfile: Dockerfile
-  #   image: ${hcc_hsail_name}
-  #   container_name: hcc-hsail
-  #   entrypoint: /bin/true
-  #   volumes:
-  #     - ${hcc_hsail_volume}
 
   # The following defines application containers, which depend on the data-only
   # containers defined above to provide their software layers
@@ -117,3 +85,19 @@ services:
       - rocr-src:ro
       - hcc-lc-src:ro
       # - hcc-hsail-src:ro
+
+  dev-ubuntu:
+    build:
+      context: ./dev
+      dockerfile: Dockerfile-ubuntu-16.04
+    devices:
+      - "/dev/kfd"
+    image: rocm/dev-ubuntu-16.04
+
+  dev-fedora:
+    build:
+      context: ./dev
+      dockerfile: Dockerfile-fedora-24
+    devices:
+      - "/dev/kfd"
+    image: rocm/dev-fedora-24

--- a/hcc-hsail/hcc-hsail-deb-dockerfile.template
+++ b/hcc-hsail/hcc-hsail-deb-dockerfile.template
@@ -7,7 +7,7 @@
 FROM ${rocr_name}
 MAINTAINER Kent Knox <kent.knox@amd>
 
-# Following assumes that the apt-get update is already set up to pull from packages.amd.com in base image
+# Following assumes that the apt-get update is already set up to pull from repo.radeon.com in base image
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   hsa-ext-rocr-dev \
   hcc_hsail && \

--- a/hcc-lc/hcc-lc-deb-dockerfile.template
+++ b/hcc-lc/hcc-lc-deb-dockerfile.template
@@ -7,7 +7,7 @@
 FROM ${rocr_image_name_deb}
 MAINTAINER Kent Knox <kent.knox@amd>
 
-# Following assumes that the apt-get update is already set up to pull from packages.amd.com in base image
+# Following assumes that the apt-get update is already set up to pull from repo.radeon.com in base image
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   hcc_lc && \
   apt-get clean && \

--- a/quick-start.md
+++ b/quick-start.md
@@ -2,17 +2,16 @@
 
 The following instructions assume a fresh/blank machine to be prepared for the ROCm + Docker environment; no additional software has been installed other than the typical stock package updating.
 
-It is my recommendation to install the rocm kernel first.  Depending on how distribution release cycles lines up, the rocm kernel is often newer than the stock kernel shipping in most linux distributions.  The newer kernel often supports newer AMD hardware better, and stock video resolutions and hardware acceleration performance are typically improved.  As of the time of this writing, ROCm officially supports Ubuntu and Fedora Linux distributions.  The following asciicast demonstrates updating the kernel on Ubuntu 14.04.  More detailed instructions can be found on the Radeon Open Compute website:
+It is recommended to install the rocm kernel first.  Depending on how distribution release cycles lines up, the rocm kernel is often newer than the stock kernel shipping in most linux distributions.  The ROCm kernel often supports newer AMD hardware better, and stock video resolutions and hardware acceleration performance are typically improved.  As of the time of this writing, ROCm officially supports Ubuntu and Fedora Linux distributions.  The following asciicast demonstrates updating the kernel on Ubuntu 14.04.  More detailed instructions can be found on the Radeon Open Compute website:
 * [Installing ROCK kernel](https://github.com/RadeonOpenCompute/ROCm#debian-repository---apt-get) on Ubuntu
 
 ### Step 1: Install rocm-kernel
-[![Install rocm-kernel](https://asciinema.org/a/cv0r34re9hp9g5hoja8vyh803.png)](https://asciinema.org/a/cv0r34re9hp9g5hoja8vyh803)
+The following is a sequence of commands to type (or cut-n-paste) into a terminal.  Where `<<<tab-complete>>>` is used in the sequence below, it is recommended to complete the string with shell tab completion to auto-complete the latest available rocm kernel:
 
 ```bash
-wget -qO - http://packages.amd.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
-sudo sh -c 'echo deb [arch=amd64] http://packages.amd.com/rocm/apt/debian/ trusty main  \
-    > /etc/apt/sources.list.d/rocm.list'
-sudo apt-get update && sudo apt-get install rocm-kernel
+wget -qO - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
+echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main | sudo tee /etc/apt/sources.list.d/rocm.list
+sudo apt-get update && sudo apt-get install compute-firmware linux-headers-4.11.0-kfd-<<<tab-complete>>> linux-image-4.11.0-kfd-<<<tab-complete>>>
 ```
 Make sure to reboot the machine after installing the ROCm kernel package to force the new kernel to load on reboot.  You can verify the ROCm kernel is loaded by typing the following command at a prompt:
 

--- a/rocr/rocr-deb-dockerfile.template
+++ b/rocr/rocr-deb-dockerfile.template
@@ -7,7 +7,7 @@
 FROM ${roct_image_name_deb}
 MAINTAINER Kent Knox <kent.knox@amd>
 
-# Following assumes that the apt-get update is already set up to pull from packages.amd.com in base image
+# Following assumes that the apt-get update is already set up to pull from repo.radeon.com in base image
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   hsa-rocr-dev && \
   apt-get clean && \

--- a/rocr/rocr-src-dockerfile.template
+++ b/rocr/rocr-src-dockerfile.template
@@ -11,8 +11,8 @@ MAINTAINER Kent Knox <kent.knox@amd>
 # HSAIL based tools (hcc-hsail) need the finalizer libraries, which are closed source and not provided on github
 # Hopefully, this can be removed in the future when dependencies on closed source blobs are removed
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl && \
-  curl -sL http://packages.amd.com/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
-  sh -c 'echo deb [arch=amd64] http://packages.amd.com/rocm/apt/debian/ trusty main > /etc/apt/sources.list.d/rocm.list' && \
+  curl -sL http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+  sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ trusty main > /etc/apt/sources.list.d/rocm.list' && \
   apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   build-essential \
   libc6-dev-i386 \

--- a/roct/roct-thunk-deb-dockerfile.template
+++ b/roct/roct-thunk-deb-dockerfile.template
@@ -10,8 +10,8 @@ MAINTAINER Kent Knox <kent.knox@amd>
 
 # Initialize the image we are working with
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl && \
-  curl -sL http://packages.amd.com/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
-  sh -c 'echo deb [arch=amd64] http://packages.amd.com/rocm/apt/debian/ ${target_distrib_codename} main > /etc/apt/sources.list.d/rocm.list' && \
+  curl -sL http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+  sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ ${target_distrib_codename} main > /etc/apt/sources.list.d/rocm.list' && \
   apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   hsakmt-roct-dev && \
   apt-get clean && \


### PR DESCRIPTION
New dockerfiles exist in a subdirectory called /dev.  These are
meant to serve as base docker images downstream dockerfiles
use in FROM statements

Fixed stale URL's and fixed up the name of the rocm kernel packages.