### PR TITLE
Added comgr rpm to CentOS dockerfile

### DIFF
--- a/dev/Dockerfile-centos-7
+++ b/dev/Dockerfile-centos-7
@@ -71,7 +71,7 @@ RUN yum install -y devtoolset-7-libatomic-devel devtoolset-7-elfutils-libelf-dev
 RUN yum clean all
 RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=http://repo.radeon.com/rocm/yum/rpm\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/rocm.repo
 
-RUN yum install -y hsakmt-roct hsakmt-roct-dev hsa-rocr-dev hsa-ext-rocr-dev rocm-opencl rocm-opencl-devel rocm-smi rocm-utils rocminfo hcc atmi hip_base hip_doc hip_hc hip_samples hsa-amd-aqlprofile rocm-clang-ocl
+RUN yum install -y hsakmt-roct hsakmt-roct-dev hsa-rocr-dev hsa-ext-rocr-dev rocm-opencl rocm-opencl-devel rocm-smi rocm-utils rocminfo hcc atmi hip_base hip_doc hip_hc hip_samples hsa-amd-aqlprofile rocm-clang-ocl comgr
 RUN yum install -y miopen-hip cxlactivitylogger miopengemm rocblas rocrand rocfft hipblas
 RUN bash -c 'echo -e "gfx803\ngfx900\ngfx906" >> /opt/rocm/bin/target.lst'
 


### PR DESCRIPTION
When building any project (i.e. rocPRIM) using the latest CentOS docker image, I get the following error: 

ld: warning: libamd_comgr.so, needed by /opt/rocm/hip/lib/libhip_hcc.so, not found

This is because the CentOS image does not have the comgr rpm installed. After installing the rpm, the issue is fixed. In my PR, I've added it to the dockerfile. The Ubuntu image has the libamd_comgr.so file in /opt/rocm/lib directory- only CentOS image has this issue.
