### PR TITLE
Update docker run commands for ROCm2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Looking for an easy start with ROCm + Docker?  The rocm/rocm-terminal image is h
 
 ```bash
 sudo docker pull rocm/rocm-terminal
-sudo docker run -it --device=/dev/kfd --device=/dev/dri --group-add video rocm/rocm-terminal
+sudo docker run -it --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video rocm/rocm-terminal
 ```
 
 ## ROCm-docker set up guide

--- a/quick-start.md
+++ b/quick-start.md
@@ -76,7 +76,7 @@ The downside to switching to the 'overlay2' storage driver after creating and wo
 git clone https://github.com/RadeonOpenCompute/ROCm-docker
 cd ROCm-docker
 sudo docker build -t rocm/rocm-terminal rocm-terminal
-sudo docker run -it --device=/dev/kfd --device=/dev/dri --group-add video rocm/rocm-terminal
+sudo docker run -it --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video rocm/rocm-terminal
 ```
 
 ### (optional) Step 4b: Build ROCm container using docker-compose


### PR DESCRIPTION
ROCm2.8 requires docker user to add additional options below to access full ROCm kernel resources:
--security-opt seccomp=unconfined