### PR TITLE
Cleanup

### DIFF
--- a/dev/Dockerfile-ubuntu-18.04
+++ b/dev/Dockerfile-ubuntu-18.04
@@ -13,5 +13,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   libelf1 \
   rocm-dev \
   build-essential && \
+# Cleaning up
+  apt-get remove -y curl gnupg && \
+  apt-get autoremove -y && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Remove curl and gnupg after Rocm is installed to make the image smaller