### PR TITLE
Update for hipcc dependencies in ROCm3.5.1

### DIFF
--- a/dev/Dockerfile-centos-7
+++ b/dev/Dockerfile-centos-7
@@ -51,6 +51,8 @@ RUN yum -y install \
     pth \
     qemu-kvm \
     re2c \
+    kmod \
+    file \
     rpm \
     rpm-build \
     subversion \

--- a/dev/Dockerfile-ubuntu-16.04
+++ b/dev/Dockerfile-ubuntu-16.04
@@ -12,6 +12,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   sudo \
   libelf1 \
   rocm-dev \
+  kmod \
+  file \
   build-essential && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*

--- a/dev/Dockerfile-ubuntu-18.04
+++ b/dev/Dockerfile-ubuntu-18.04
@@ -11,6 +11,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo \
   libelf1 \
+  kmod \
+  file \
   rocm-dev \
   build-essential && \
   apt-get clean && \

--- a/rocm-terminal/Dockerfile
+++ b/rocm-terminal/Dockerfile
@@ -10,7 +10,7 @@
 # If it is desired to run the container manually through the docker command-line, the following is an example
 # 'docker run -it --rm -v [host/directory]:[container/directory]:ro <user-name>/<project-name>'.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Peng Sun <Peng.Sun@amd.com>
 
 # Initialize the image
@@ -26,6 +26,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   git \
   vim-nox \
   cmake-curses-gui \
+  kmod \
+  gnupg \
+  file \
   rocm-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This commit updates the following items:
1. Add kmod, file packages for hipcc
2. move rocm-terminal base OS to Ubuntu18.04