### PR TITLE
Dev dockerfile updates for ROCm3.7

### DIFF
--- a/dev/Dockerfile-centos-7
+++ b/dev/Dockerfile-centos-7
@@ -75,6 +75,7 @@ RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=http://repo.radeon.com/rocm/yum/rpm\nena
 
 RUN yum install -y hsakmt-roct hsakmt-roct-dev hsa-rocr-dev hsa-ext-rocr-dev rocm-opencl rocm-opencl-devel rocm-smi rocm-utils rocminfo hcc atmi hip_base hip_doc hip_hc hip_samples hsa-amd-aqlprofile rocm-clang-ocl comgr
 RUN yum install -y miopen-hip cxlactivitylogger miopengemm rocblas rocrand rocfft hipblas
+RUN ln -s /opt/rocm-3.7.0 /opt/rocm
 RUN bash -c 'echo -e "gfx803\ngfx900\ngfx906" >> /opt/rocm/bin/target.lst'
 
 # Set ENV to enable devtoolset7 by default 

--- a/dev/Dockerfile-centos-7
+++ b/dev/Dockerfile-centos-7
@@ -73,10 +73,7 @@ RUN yum install -y devtoolset-7-libatomic-devel devtoolset-7-elfutils-libelf-dev
 RUN yum clean all
 RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=http://repo.radeon.com/rocm/yum/rpm\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/rocm.repo
 
-RUN yum install -y hsakmt-roct hsakmt-roct-dev hsa-rocr-dev hsa-ext-rocr-dev rocm-opencl rocm-opencl-devel rocm-smi rocm-utils rocminfo hcc atmi hip_base hip_doc hip_hc hip_samples hsa-amd-aqlprofile rocm-clang-ocl comgr
-RUN yum install -y miopen-hip cxlactivitylogger miopengemm rocblas rocrand rocfft hipblas
-RUN ln -s /opt/rocm-3.7.0 /opt/rocm
-RUN bash -c 'echo -e "gfx803\ngfx900\ngfx906" >> /opt/rocm/bin/target.lst'
+RUN yum install -y rocm-dev
 
 # Set ENV to enable devtoolset7 by default 
 ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:/opt/rocm/hcc/bin:/opt/rocm/hip/bin:/opt/rocm/bin:/opt/rocm/hcc/bin:${PATH:+:${PATH}}

--- a/dev/Dockerfile-ubuntu-20.04
+++ b/dev/Dockerfile-ubuntu-20.04
@@ -1,19 +1,19 @@
 # This dockerfile is meant to serve as a rocm base image.  It registers the debian rocm package repository, and
 # installs the rocm-dev package.
 
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 LABEL maintainer=peng.sun@amd.com
 
 # Register the ROCM package repository, and install rocm-dev package
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl libnuma-dev gnupg \
   && curl -sL http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | apt-key add - \
   && printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | tee /etc/apt/sources.list.d/rocm.list \
   && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo \
   libelf1 \
-  rocm-dev \
   kmod \
   file \
+  rocm-dev \
   build-essential && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
1. Deprecate and remove Ubuntu16.04 base docker. Starting ROCm3.7 ROCm dropped Ubuntu16.04 support.
2. Add Ubuntu20.04 based develop dockerfile.
3. Explicit add symbolic link of "/opt/rocm --> /opt/rocm-3.7.0" in the CentOS based dockerfile