### PR TITLE
Use proper certificate verification

### DIFF
--- a/dev/Dockerfile-ubuntu-18.04
+++ b/dev/Dockerfile-ubuntu-18.04
@@ -11,9 +11,11 @@ RUN \
     curl libnuma-dev gnupg \
   && \
   curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
-  printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | tee /etc/apt/sources.list.d/rocm.list && \
+  printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | \
+    tee /etc/apt/sources.list.d/rocm.list \
+  && \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     sudo \
     libelf1 \
     kmod \

--- a/dev/Dockerfile-ubuntu-18.04
+++ b/dev/Dockerfile-ubuntu-18.04
@@ -5,15 +5,21 @@ FROM ubuntu:18.04
 LABEL maintainer=peng.sun@amd.com
 
 # Register the ROCM package repository, and install rocm-dev package
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl libnuma-dev gnupg \
-  && curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - \
-  && printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | tee /etc/apt/sources.list.d/rocm.list \
-  && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-  sudo \
-  libelf1 \
-  kmod \
-  file \
-  rocm-dev \
-  build-essential && \
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+    curl libnuma-dev gnupg \
+  && \
+  curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
+  printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | tee /etc/apt/sources.list.d/rocm.list && \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    sudo \
+    libelf1 \
+    kmod \
+    file \
+    rocm-dev \
+    build-essential \
+  && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*

--- a/dev/Dockerfile-ubuntu-18.04
+++ b/dev/Dockerfile-ubuntu-18.04
@@ -8,10 +8,15 @@ LABEL maintainer=peng.sun@amd.com
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-    curl libnuma-dev gnupg \
+    # For cURL
+    ca-certificates \
+    curl \
+    gnupg2 \
+    # For ROCm
+    libnuma-dev \
   && \
-  curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
-  printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | \
+  curl -sL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
+  printf "deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ xenial main" | \
     tee /etc/apt/sources.list.d/rocm.list \
   && \
   apt-get update && \

--- a/dev/Dockerfile-ubuntu-20.04
+++ b/dev/Dockerfile-ubuntu-20.04
@@ -16,7 +16,7 @@ RUN \
     libnuma-dev \
   && \
   curl -sL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
-  printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | \
+  printf "deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ xenial main" | \
     tee /etc/apt/sources.list.d/rocm.list \
   && \
   apt-get update && \

--- a/dev/Dockerfile-ubuntu-20.04
+++ b/dev/Dockerfile-ubuntu-20.04
@@ -5,15 +5,25 @@ FROM ubuntu:20.04
 LABEL maintainer=peng.sun@amd.com
 
 # Register the ROCM package repository, and install rocm-dev package
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl libnuma-dev gnupg \
-  && curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - \
-  && printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | tee /etc/apt/sources.list.d/rocm.list \
-  && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-  sudo \
-  libelf1 \
-  kmod \
-  file \
-  rocm-dev \
-  build-essential && \
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+    curl \
+    gnupg \
+    libnuma-dev \
+  && \
+  curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
+  printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | \
+    tee /etc/apt/sources.list.d/rocm.list \
+  && \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+    sudo \
+    libelf1 \
+    kmod \
+    file \
+    rocm-dev \
+    build-essential \
+  && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*

--- a/dev/Dockerfile-ubuntu-20.04
+++ b/dev/Dockerfile-ubuntu-20.04
@@ -15,7 +15,7 @@ RUN \
     # For ROCm
     libnuma-dev \
   && \
-  curl -L https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
+  curl -sL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
   printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | \
     tee /etc/apt/sources.list.d/rocm.list \
   && \

--- a/dev/Dockerfile-ubuntu-20.04
+++ b/dev/Dockerfile-ubuntu-20.04
@@ -8,11 +8,14 @@ LABEL maintainer=peng.sun@amd.com
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+    # For cURL
+    ca-certificates \
     curl \
-    gnupg \
+    gnupg2 \
+    # For ROCm
     libnuma-dev \
   && \
-  curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
+  curl -L https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
   printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | \
     tee /etc/apt/sources.list.d/rocm.list \
   && \


### PR DESCRIPTION
Currently, the repository URL uses the HTTP protocol without TLS/SSL. This allows for man-in-the-middle attacks where an attacker imposes as the repository server. The packages installed from the repository are being installed using root rights. This allows a manipulated package to gain ring-0 access to the target machine.

## Mitigation by user interaction impossible

The installation only happens after the user has confirmed (using the --yes flag in the apt install command) the package installation identified by name and host, both of which can be spoofed. Therefore, the point of no return is already in the past when this attack happens.

## Checking certificates

I provided a patch where the URL uses the HTTPS protocol with TLS/SSL. This verifies the authenticity of the host at repo.radeon.com against the certificate chain provided by Canonical for their Ubuntu Linux distribution. Since these are provided with the base image, this seems like a very trustworthy source for this image.

(I also reformatted the file to make it and my changes more readable, beforehand.)

## Breadth of this issue

This issue seems to affect all (CentOS 7, Fedora 24, Ubuntu 18.04, and Ubuntu 20.04) the dev packages. A quick search reveals but more affected dockerfiles, templates and Markdown files:

<https://github.com/RadeonOpenCompute/ROCm-docker/search?q=http%3A%2F%2F>