### PR TITLE
add rocm-user to video group

### DIFF
--- a/rocm-terminal/Dockerfile
+++ b/rocm-terminal/Dockerfile
@@ -39,7 +39,7 @@ COPY sudo-nopasswd /etc/sudoers.d/sudo-nopasswd
 # This is meant to be used as an interactive developer container
 # Create user rocm-user as member of sudo group
 # Append /opt/rocm/bin to the system PATH variable
-RUN useradd --create-home -G sudo --shell /bin/bash rocm-user
+RUN useradd --create-home -G sudo,video --shell /bin/bash rocm-user
 #    sed --in-place=.rocm-backup 's|^\(PATH=.*\)"$|\1:/opt/rocm/bin"|' /etc/environment
 
 USER rocm-user


### PR DESCRIPTION
The docs on the landing page demonstrate the recommended way of launching rocm-terminal, however the option used there (`--group-add`) is unavailable when used in tandem with GitLab runners. The [`[runners.docker]`](https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnersdocker-section) section of `/etc/gitlab-runner/config.toml` doesn't expose this docker option, hence in all of our CI scripts, any command actually using the GPUs need to be prefixed with `sudo`. This burns engineer time every time someone stumbles upon this every 3-4 months by seeing errors in CI of devices not being present.

I see no reason why rocm-user couldn't be made a member of the video group when the image is created; I can't think of a use case where one wishes to run this image purposfully wanting to run device code with elevated priviliges and _only_ be able to run them that way.

Quote from [SO](https://stackoverflow.com/a/41101828/1476661):

> If `--group-add` option alone is specified without `--user` and the image does have the user declared( via `USER` instruction in Dockerfile from which the image got created), group modifications happen to the declared user in the container.

This addition to the recommended command-line has no effect on the interplay of the container and the host system, it is totally self-confined. **If** there's no use case behind `rocm-user` being absent from the `video` group, please accept the PR, as it's burning the time of users for no good reason.

Tested, it works as intended.