### PR TITLE
Add Python 3 to rocm-terminal for rocm-smi

### DIFF
--- a/rocm-terminal/Dockerfile
+++ b/rocm-terminal/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   cmake-curses-gui \
   kmod \
   file \
+  python3 \
   rocm-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds Python 3 to rocm-terminal as required by rocm-smi.

Without Python 3 rocm-smi terminates with:

```sh
rocm-user@647b73024a89:~$ rocm-smi
/usr/bin/env: 'python3': No such file or directory
```

With Python 3 it works as expected:

```sh
rocm-user@eb88112dd89e:~$ rocm-smi

======================= ROCm System Management Interface =======================
# ... etc ...
```