### PR TITLE
adding render group with gid 109 to make sure rocminfo runs even with…

### DIFF
--- a/dev/Dockerfile-ubuntu-20.04
+++ b/dev/Dockerfile-ubuntu-20.04
@@ -23,3 +23,4 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   build-essential && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+RUN  groupadd -g 109 render

--- a/dev/Dockerfile-ubuntu-20.04-complete
+++ b/dev/Dockerfile-ubuntu-20.04-complete
@@ -25,3 +25,4 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   build-essential && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+RUN  groupadd -g 109 render


### PR DESCRIPTION
… non-root-user

test results:
fpadmin@rocm-framework-52:~/ROCm-docker/dev$ docker run -u 1000 -it --device=/dev/kfd --device=/dev/dri --group-add video --group-add render --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v /data:/data --shm-size=16G 0a29866b8289 /bin/bash
I have no name!@39764af76254:/$ rocminfo | grep gfx*
  Name:                    gfx90a
      Name:                    amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack-
  Name:                    gfx90a
      Name:                    amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack-

I have no name!@39764af76254:/$ ls -lart /dev/dri/
total 0
crw-rw---- 1 root render 226, 129 Aug 22 21:34 renderD129
crw-rw---- 1 root render 226, 128 Aug 22 21:34 renderD128
crw-rw---- 1 root video  226,   2 Aug 22 21:34 card2
crw-rw---- 1 root video  226,   1 Aug 22 21:34 card1
crw-rw---- 1 root video  226,   0 Aug 22 21:34 card0
drwxr-xr-x 2 root root        140 Aug 22 21:34 .
drwxr-xr-x 6 root root        400 Aug 22 21:34 ..
I have no name!@39764af76254:/$ ls -lart /dev/kfd
crw-rw---- 1 root render 509, 0 Aug 22 21:34 /dev/kfd
I have no name!@39764af76254:/$