### PR TITLE
Add missing libraries in Ubuntu containers.

### DIFF
--- a/dev/Dockerfile-ubuntu-20.04
+++ b/dev/Dockerfile-ubuntu-20.04
@@ -15,6 +15,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo \
   libelf1 \
+  libdw1 \
+  libfile-which-perl \
+  liburi-perl \
   kmod \
   file \
   python3-dev \

--- a/dev/Dockerfile-ubuntu-20.04-complete
+++ b/dev/Dockerfile-ubuntu-20.04-complete
@@ -16,6 +16,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo \
   libelf1 \
+  libdw1 \
+  libfile-which-perl \
+  liburi-perl \
   kmod \
   file \
   python3-dev \

--- a/dev/Dockerfile-ubuntu-22.04
+++ b/dev/Dockerfile-ubuntu-22.04
@@ -17,6 +17,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo \
   libelf1 \
+  libdw1 \
+  libfile-which-perl \
+  liburi-perl \
   kmod \
   file \
   python3-dev \

--- a/dev/Dockerfile-ubuntu-22.04-complete
+++ b/dev/Dockerfile-ubuntu-22.04-complete
@@ -17,6 +17,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo \
   libelf1 \
+  libdw1 \
+  libfile-which-perl \
+  liburi-perl \
   kmod \
   file \
   python3-dev \

--- a/dev/Dockerfile-ubuntu-24.04
+++ b/dev/Dockerfile-ubuntu-24.04
@@ -17,6 +17,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo \
   libelf1 \
+  libdw1t64 \
+  libfile-which-perl \
+  liburi-perl \
   kmod \
   file \
   python3-dev \

--- a/dev/Dockerfile-ubuntu-24.04-complete
+++ b/dev/Dockerfile-ubuntu-24.04-complete
@@ -17,6 +17,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo \
   libelf1 \
+  libdw1t64 \
+  libfile-which-perl \
+  liburi-perl \
   kmod \
   file \
   python3-dev \


### PR DESCRIPTION
## Motivation

Using the rocm/dev-ubuntu-24.04:latest container I noticed that we couldn't run rocprofv3, roc-obj-ls, and roc-obj-extract inside the container because of missing dependencies. rocprofv3 requires libdw1. roc-obj-ls and roc-obj-extract require libfile-which-perl and liburi-perl.

This patch fixes the issue adding these dependencies to the ubuntu Dockerfiles.

## Technical Details

## Test Plan

## Test Result

Adding these dependencies fixed the issues.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
